### PR TITLE
Update workflows to use ubuntu-24.04 and adjust Nexus credentials.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -12,7 +12,7 @@ jobs:
   analyze:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip') }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew build test
 
       - name: Publish to Nexus
-        run: ./gradlew publishReleasePublicationToReleasesRepository -Dorg.gradle.unsafe.configuration-cache=false
+        run: ./gradlew publishReleasePublicationToReleasesRepository publishSnapshotPublicationToSnapshotsRepository -Dorg.gradle.unsafe.configuration-cache=false
         env:
-          REPOSITORY_USERNAME: ${{ secrets.REPOSITORY_USERNAME }}
-          REPOSITORY_PASSWORD: ${{ secrets.REPOSITORY_PASSWORD }}
+          REPOSITORY_USERNAME: ${{ secrets.NEXUS_PUBLIC_LIBRARIES_USERNAME }}
+          REPOSITORY_PASSWORD: ${{ secrets.NEXUS_PUBLIC_LIBRARIES_PASSWORD }}

--- a/.github/workflows/publishSnapshot.yml
+++ b/.github/workflows/publishSnapshot.yml
@@ -2,8 +2,6 @@ name: Publish snapshot to Repository
 
 on:
   workflow_dispatch:
-  release:
-    types: [ published ]
 
 
 env:
@@ -11,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -43,5 +41,5 @@ jobs:
       - name: Publish to Nexus
         run: ./gradlew publishSnapshotPublicationToSnapshotsRepository -Dorg.gradle.unsafe.configuration-cache=false
         env:
-          REPOSITORY_USERNAME: ${{ secrets.REPOSITORY_USERNAME }}
-          REPOSITORY_PASSWORD: ${{ secrets.REPOSITORY_PASSWORD }}
+          REPOSITORY_USERNAME: ${{ secrets.NEXUS_PUBLIC_LIBRARIES_USERNAME }}
+          REPOSITORY_PASSWORD: ${{ secrets.NEXUS_PUBLIC_LIBRARIES_PASSWORD }}

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   setup_labels:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to contribute 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- New or updated content

---

#### Description

- Closes # <!-- Add an issue number if this PR resolves one -->
- Upgraded all workflows from ubuntu-22.04 to ubuntu-24.04 for consistency and compatibility.
- Replaced Nexus credential secrets with updated environment variables.
- Enabled publishing snapshots alongside releases in publishRelease workflow.
- Removed unused `release` trigger from publishSnapshot workflow.<!-- What does this PR change? Please provide a brief summary. -->

<!--
Did you make any visual changes? If so, a screenshot or video would be helpful.

Please keep your changes minimal and focused.
Pull requests with redundant code may be rejected.

If you create new classes or methods, adding documentation is appreciated.]


Pull request titles must be in English.
-->


---

