### PR TITLE
Update default JDK to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 Make sure you have the following installed:
 
-- **Java Development Kit (JDK)** version 8 or later.
+- **Java Development Kit (JDK)** version 17 or later.
 
 ---
 

--- a/build-logic/src/main/groovy/buildlogic.java-toolchain-conventions.gradle
+++ b/build-logic/src/main/groovy/buildlogic.java-toolchain-conventions.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.github.ben-manes.versions'
 }
 
-def javaVersion = properties.getOrDefault('java.version', 8) as int
+def javaVersion = properties.getOrDefault('java.version', 21) as int
 def javaCompatSource = properties.getOrDefault('java.compatibility.source', javaVersion) as int
 def javaCompatTarget = properties.getOrDefault('java.compatibility.target', javaCompatSource) as int
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -3,6 +3,6 @@ version: "1.0"
 profile:
   name: qodana.recommended
 
-projectJDK: "8"
+projectJDK: "21"
 
 linter: jetbrains/qodana-jvm:latest


### PR DESCRIPTION
Updated default JDK version from 8 to 21 in gradle conventions and qodana config. Readme JDK requirement updated to version 17 or later.

<!-- Thank you for opening a PR! We really appreciate you taking the time to contribute 🙌 -->
<!-- Pull request titles must be in English. -->

#### What kind of changes does this PR include?

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Minor content fixes (broken links, typos, exceptions, etc.)
- [ ] New or updated content
- [ ] Documentation updates
- [ ] Assets content
- [ ] Code refactoring
- [ ] Dependency updates
- [x] Runtime updates
- [ ] Build Logic updates
- [ ] Other

---

#### Description

<!--
Did you make any visual changes? If so, a screenshot or video would be helpful.
-->

- <!-- Please provide a brief summary of the changes introduced by this PR. -->

---

## Does this PR introduce a breaking change?

<!--
We prefer to avoid breaking changes.
We will only accept PRs with breaking changes if they have been discussed in an issue first.

Please check one of the boxes below to indicate if this PR introduces a breaking change.
-->

- [ ] Yes
- [ ] No

---

## Additional Notes

- <!-- If there's anything else you want to add, mention it here. -->

---

## Related Issue or PR

- <!-- Add an issue or PR number if this PR is related to one. -->

<!--
If you are suggesting a new feature or change, please discuss it in an issue first.
If you are fixing a bug, there should be an issue describing it using a bug report template.
-->

---

<!--
Please keep your changes minimal and focused.
Pull requests with redundant code may be rejected.

If you create new classes or methods, adding documentation is appreciated.
-->
